### PR TITLE
fix: convert decimals to number

### DIFF
--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -123,12 +123,12 @@ export function amountFormatter(amount, baseDecimals = 18, displayDecimals = 3, 
     // if balance is less than the minimum display amount
     if (amount.lt(minimumDisplayAmount)) {
       return useLessThan
-        ? `<${ethers.utils.formatUnits(minimumDisplayAmount, baseDecimals)}`
-        : `${ethers.utils.formatUnits(amount, baseDecimals)}`
+        ? `<${ethers.utils.formatUnits(minimumDisplayAmount, baseDecimals.toNumber())}`
+        : `${ethers.utils.formatUnits(amount, baseDecimals.toNumber())}`
     }
     // if the balance is greater than the minimum display amount
     else {
-      const stringAmount = ethers.utils.formatUnits(amount, baseDecimals)
+      const stringAmount = ethers.utils.formatUnits(amount, baseDecimals.toNumber())
 
       // if there isn't a decimal portion
       if (!stringAmount.match(/\./)) {


### PR DESCRIPTION
Units are expected to be either a string: `wei`, `ether` or numbers: `0` `1`. 


If you pass a bigNumber or a string as `2` it breaks. I will send a PR to ether.js in order to fix the string case.